### PR TITLE
修复手动滑动时，自动播放失效的问题

### DIFF
--- a/js/swipeSlide.js
+++ b/js/swipeSlide.js
@@ -370,6 +370,7 @@
                 me._index = 0;
                 setTimeout(function(){
                     fnScroll(me, 0);
+                    fnAutoSlide(me);
                 //    return;
                 },300);
             }else if(me._index < 0){
@@ -378,6 +379,7 @@
                 setTimeout(function(){
                     fnScroll(me, 0);
                 //   return;
+                    fnAutoSlide(me);
                 },300);
             }else{
                 fnScroll(me, num);

--- a/js/swipeSlide.js
+++ b/js/swipeSlide.js
@@ -6,7 +6,7 @@
  */
 ;(function(win,$){
     'use strict';
-    
+
     // 判断IE
     var browser = {
         ie10 : win.navigator.msPointerEnabled,
@@ -151,7 +151,7 @@
             clearTimeout(me.timer);
             me.timer = setTimeout(fnGetSlideDistance,150);
         });
-        
+
         // 获取轮播宽度
         function fnGetSlideDistance(){
             var $li = me.opts.ul.children();
@@ -237,7 +237,7 @@
                 me.isScrolling = !!(Math.abs(me._moveY) >= Math.abs(me._moveX));
             }
         }
-        
+
         // 距离
         if(me.isScrolling){
             if (e.preventDefault) e.preventDefault();
@@ -353,7 +353,7 @@
                     // 滑到第一屏
                     if(me._index == 0){
                         fnLazyLoad(me, me._liLength);
-                    
+
                     // 第一屏，继续往前滑动
                     }else if(me._index < 0){
                         fnLazyLoad(me, me._liLength-1);
@@ -370,14 +370,14 @@
                 me._index = 0;
                 setTimeout(function(){
                     fnScroll(me, 0);
-                    return;
+                //    return;
                 },300);
             }else if(me._index < 0){
                 fnScroll(me, num);
                 me._index = me._liLength-1;
                 setTimeout(function(){
                     fnScroll(me, 0);
-                    return;
+                //   return;
                 },300);
             }else{
                 fnScroll(me, num);


### PR DESCRIPTION
#14 [手指滑动导致自动滑动失效 ](https://github.com/ximan/swipeSlide/issues/14)

手动滑动的时候会先删除定时器，在向上一个循环，或者下一个循环滑动时，代码中添加了

```
        // 如果是连续滚动  367行
        if (me.opts.continuousScroll) {
            if (me._index >= me._liLength) {
                fnScroll(me, num);
                me._index = 0;
                setTimeout(function() {
                    console.log("hello");
                    fnScroll(me, 0);
                    return;//return 了，导致 webkitTransitionEnd事件不会触发
                }, 300);
            } else if (me._index < 0) {
                fnScroll(me, num);
                me._index = me._liLength - 1;
                setTimeout(function() {
                    fnScroll(me, 0);
                    return; //return 了，导致 webkitTransitionEnd事件不会触发
                }, 300);
            } else {
                fnScroll(me, num);
            }
        }
```

自动播放失效。
将return 删除即可。 但是不知道会不会有其他的问题，还请详细测试下。多谢！
